### PR TITLE
ipad screenHeight 계산시 항상 fullScreen 기준으로 계산되는 오류 수정

### DIFF
--- a/Sources/Controller/SheetContentsViewController.swift
+++ b/Sources/Controller/SheetContentsViewController.swift
@@ -152,7 +152,7 @@ private extension SheetContentsViewController {
         let bottomToolBarHeight: CGFloat = isToolBarHidden ? UIEdgeInsets.safeAreaInsets.bottom : SheetManager.shared.options.sheetToolBarHeight + UIEdgeInsets.safeAreaInsets.bottom
         collectionView?.layoutIfNeeded()
 
-        let screenHeight = UIScreen.main.bounds.height
+        let screenHeight = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.coordinateSpace.bounds.size.height ?? UIScreen.main.bounds.height
         let contentHeight = collectionView?.contentSize.height ?? 0
         let visibleHeight = min(contentHeight - layout.settings.topMargin, visibleContentsHeight)
         topMargin = isFullScreenContent ? 0 : max(screenHeight - layout.settings.minTopMargin - visibleHeight - bottomToolBarHeight, 0)


### PR DESCRIPTION
UIScreen.main.bounds.height 는 Ipad stageMode, slideOver 에서도 fullScreen height을 리턴하기 때문에
현재 scene의 height를 반환하도록 수정