### PR TITLE
forSupplementaryViewOfKind sectionfooter 수정

### DIFF
--- a/Sources/Layout/SheetContentsLayout.swift
+++ b/Sources/Layout/SheetContentsLayout.swift
@@ -99,7 +99,7 @@ extension SheetContentsLayout {
             contentHeight += currentSectionInset.bottom
 
             if let sectionFooterSize = settings.sectionFooterSize?(IndexPath(item: 1, section: section)), sectionFooterSize != .zero {
-                let sectionFooterAttributes = SheetLayoutAttributes(forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, with: IndexPath(item: 1, section: section))
+                let sectionFooterAttributes = SheetLayoutAttributes(forSupplementaryViewOfKind: SheetLayoutElement.sectionFooter.kind, with: IndexPath(item: 1, section: section))
                 prepareSupplementrayElement(size: sectionFooterSize, type: .sectionFooter, attributes: sectionFooterAttributes)
             }
         }


### PR DESCRIPTION
https://github.com/grayjang/Sheet/commit/3652d1c5fe4b9fa525cf793389764323bac76e6d

위 수정 내용에서 
UICollectionView.elementKindSectionHeader -> SheetLayoutElement.sectionHeader.kind
UICollectionView.elementKindSectionFooter -> SheetLayoutElement.sectionFooter.kind

로 변경이 있었는데 그중 sectionFooter가 누락된 부분이 있었습니다